### PR TITLE
Fix Lightning checkpoint indexing

### DIFF
--- a/src/ava/models/lightning_vae.py
+++ b/src/ava/models/lightning_vae.py
@@ -560,10 +560,11 @@ class VAECheckpointCallback(pl.Callback):
 			return
 		if self.save_freq is None:
 			return
-		epoch = int(trainer.current_epoch)
-		if epoch <= 0 or epoch % self.save_freq != 0:
+		completed_epoch = int(trainer.current_epoch) + 1
+		if completed_epoch % self.save_freq != 0:
 			return
-		filename = f"checkpoint_{epoch:03d}.tar"
+		pl_module.vae.epoch = completed_epoch
+		filename = f"checkpoint_{completed_epoch:03d}.tar"
 		pl_module.vae.save_state(filename)
 
 

--- a/src/ava/models/vae.py
+++ b/src/ava/models/vae.py
@@ -854,9 +854,9 @@ class VAE(nn.Module):
 				loss = self.test_epoch(loaders['test'])
 				self.loss['test'][epoch] = loss
 			# Save the model.
-			if (save_freq is not None) and (epoch % save_freq == 0) and \
-					(epoch > 0):
-				filename = "checkpoint_"+str(epoch).zfill(3)+'.tar'
+			completed_epoch = epoch + 1
+			if (save_freq is not None) and (completed_epoch % save_freq == 0):
+				filename = "checkpoint_"+str(completed_epoch).zfill(3)+'.tar'
 				self.save_state(filename)
 			# Plot reconstructions.
 			if (vis_freq is not None) and (epoch % vis_freq == 0):

--- a/tests/models/test_lightning_training.py
+++ b/tests/models/test_lightning_training.py
@@ -189,6 +189,30 @@ def test_lightning_checkpoint_loads_legacy(tmp_path):
 	assert 0 in loaded.loss["train"]
 
 
+def test_lightning_saves_checkpoint_after_first_completed_epoch(tmp_path):
+	_set_seed(211)
+	data = torch.randn(6, 128, 128)
+	loaders = _make_loaders(data)
+	save_dir = tmp_path / "lightning_first_epoch_ckpt"
+
+	train_vae(
+		loaders,
+		save_dir=str(save_dir),
+		epochs=1,
+		test_freq=None,
+		save_freq=1,
+		vis_freq=None,
+		trainer_kwargs={
+			"accelerator": "cpu",
+			"devices": 1,
+			"enable_progress_bar": False,
+			"enable_model_summary": False,
+		},
+	)
+
+	assert (save_dir / "checkpoint_001.tar").exists()
+
+
 def test_mps_mixed_precision_is_overridden_to_fp32(tmp_path):
 	if not (hasattr(torch.backends, "mps") and torch.backends.mps.is_available()):
 		pytest.skip("MPS not available for this test.")


### PR DESCRIPTION
## Summary
- save a legacy checkpoint after the first completed epoch in both Lightning and legacy training loops
- use completed-epoch numbering so the first save is checkpoint_001.tar
- add a one-epoch regression test covering the Lightning path

## Testing
- pytest -q tests/models/test_lightning_training.py (skipped in local env because Lightning test deps are unavailable)
- python -m py_compile src/ava/models/lightning_vae.py src/ava/models/vae.py tests/models/test_lightning_training.py
